### PR TITLE
Fixed unnecessary namespace importing cause unity build failed.

### DIFF
--- a/src/Utf8Json/Formatters/CollectionFormatters.cs
+++ b/src/Utf8Json/Formatters/CollectionFormatters.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;


### PR DESCRIPTION
This error prevent me from building my unity game.
Unity version:2017.2f03

Error info:
Assets/Plugins/Utf8Json/Formatters/CollectionFormatters.cs(3,26): error CS0234: The type or namespace name `Concurrent' does not exist in the namespace `System.Collections'. Are you missing an assembly reference?
