### PR TITLE
Fix 2 practical issues encountered when replacing SignalR serialization mechanism.

### DIFF
--- a/src/Utf8Json/JsonReader.cs
+++ b/src/Utf8Json/JsonReader.cs
@@ -1100,6 +1100,7 @@ namespace Utf8Json
         public long ReadInt64()
         {
             SkipWhiteSpace();
+            var hasQuote = SkipQuotation();
 
             int readCount;
             var v = NumberConverter.ReadInt64(bytes, offset, out readCount);
@@ -1109,10 +1110,80 @@ namespace Utf8Json
             }
 
             offset += readCount;
+
+            if (hasQuote)
+                SkipQuotation();
+
             return v;
         }
 
-        public byte ReadByte()
+        private bool SkipQuotation()
+        {
+            var hasQuote = false;
+            for (int i = offset; i < bytes.Length; i++)
+            {
+                switch (bytes[i])
+                {
+                    case (byte)'"': // Space
+                    case (byte)'\'': // Space
+                        hasQuote = true;
+                        continue;
+                    // optimize skip jumptable
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 3:
+                    case 4:
+                    case 5:
+                    case 6:
+                    case 7:
+                    case 8:
+                    case 9:
+                    case 10:
+                    case 11:
+                    case 12:
+                    case 13:
+                    case 14:
+                    case 15:
+                    case 16:
+                    case 17:
+                    case 18:
+                    case 19:
+                    case 20:
+                    case 21:
+                    case 22:
+                    case 23:
+                    case 24:
+                    case 25:
+                    case 26:
+                    case 27:
+                    case 28:
+                    case 29:
+                    case 30:
+                    case 31:
+                    case 33:
+                    case 35:
+                    case 36:
+                    case 37:
+                    case 38:
+                    case 40:
+                    case 41:
+                    case 42:
+                    case 43:
+                    case 44:
+                    case 45:
+                    case 46:
+                    default:
+                        offset = i;
+                        return hasQuote; // end
+                }
+            }
+
+            offset = bytes.Length;
+            return hasQuote;
+        }
+
+    public byte ReadByte()
         {
             return checked((byte)ReadUInt64());
         }
@@ -1130,6 +1201,7 @@ namespace Utf8Json
         public ulong ReadUInt64()
         {
             SkipWhiteSpace();
+            var hasQuote = SkipQuotation();
 
             int readCount;
             var v = NumberConverter.ReadUInt64(bytes, offset, out readCount);
@@ -1138,6 +1210,10 @@ namespace Utf8Json
                 throw CreateParsingException("Number Token");
             }
             offset += readCount;
+
+            if (hasQuote)
+                SkipQuotation();
+
             return v;
         }
 

--- a/src/Utf8Json/JsonWriter.cs
+++ b/src/Utf8Json/JsonWriter.cs
@@ -315,7 +315,11 @@ namespace Utf8Json
 
         public void WriteUInt64(ulong value)
         {
+            BinaryUtil.EnsureCapacity(ref buffer, offset, 2);
+            buffer[offset++] = (byte)'\"';
             offset += NumberConverter.WriteUInt64(ref buffer, offset, value);
+            BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
+            buffer[offset++] = (byte)'\"';
         }
 
 #if NETSTANDARD
@@ -344,7 +348,11 @@ namespace Utf8Json
 
         public void WriteInt64(long value)
         {
+            BinaryUtil.EnsureCapacity(ref buffer, offset, 2);
+            buffer[offset++] = (byte)'\"';
             offset += NumberConverter.WriteInt64(ref buffer, offset, value);
+            BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
+            buffer[offset++] = (byte)'\"';
         }
 
         public void WriteString(string value)

--- a/src/Utf8Json/Resolvers/EnumResolver.cs
+++ b/src/Utf8Json/Resolvers/EnumResolver.cs
@@ -15,6 +15,9 @@ namespace Utf8Json.Resolvers
         public static readonly IJsonFormatterResolver Default = EnumDefaultResolver.Instance;
         /// <summary>Serialize as Value.</summary>
         public static readonly IJsonFormatterResolver UnderlyingValue = EnumUnderlyingValueResolver.Instance;
+
+        /// <summary>Serialize property value as underlying value, property name as name</summary>
+        public static readonly IJsonFormatterResolver UnderlyingValueOfPropertyValueOnly = EnumPropertyValueUnderlyingValueResolver.Instance;
     }
 }
 
@@ -60,7 +63,7 @@ namespace Utf8Json.Resolvers.Internal
                 }
                 else if (typeof(T).IsEnum)
                 {
-                    formatter = (IJsonFormatter<T>)(object)new EnumFormatter<T>(true);
+                    formatter = (IJsonFormatter<T>)(object)new EnumFormatter<T>(true, true);
                 }
             }
         }
@@ -106,9 +109,55 @@ namespace Utf8Json.Resolvers.Internal
                 }
                 else if (typeof(T).IsEnum)
                 {
-                    formatter = (IJsonFormatter<T>)(object)new EnumFormatter<T>(false);
+                    formatter = (IJsonFormatter<T>)(object)new EnumFormatter<T>(false, false);
                 }
             }
         }
     }
-}
+
+    internal sealed class EnumPropertyValueUnderlyingValueResolver : IJsonFormatterResolver
+    {
+        public static readonly IJsonFormatterResolver Instance = new EnumPropertyValueUnderlyingValueResolver();
+
+        EnumPropertyValueUnderlyingValueResolver()
+        {
+        }
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                var ti = typeof(T).GetTypeInfo();
+
+                if (ti.IsNullable())
+                {
+                    // build underlying type and use wrapped formatter.
+                    ti = ti.GenericTypeArguments[0].GetTypeInfo();
+                    if (!ti.IsEnum)
+                    {
+                        return;
+                    }
+
+                    var innerFormatter = Instance.GetFormatterDynamic(ti.AsType());
+                    if (innerFormatter == null)
+                    {
+                        return;
+                    }
+                    formatter = (IJsonFormatter<T>)Activator.CreateInstance(typeof(StaticNullableFormatter<>).MakeGenericType(ti.AsType()), new object[] { innerFormatter });
+                    return;
+                }
+                else if (typeof(T).IsEnum)
+                {
+                    formatter = (IJsonFormatter<T>)(object)new EnumFormatter<T>(false, true);
+                }
+            }
+        }}
+
+    }


### PR DESCRIPTION
One is the ability to use enum name on dictionary key and enum value on anything else.
The other is since the javascript engine of web browser only supports 53bit integer, it's not enough to hold a full c# long.  (we use long as entity's identity type), it must be quoted to be a string, which we have done earlier by using custom converter on json.net library.
Hope it helps on your future development.