### PR TITLE
Deserialize Enum from lower case string

### DIFF
--- a/src/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/Utf8Json/Formatters/EnumFormatter.cs
@@ -166,6 +166,10 @@ namespace Utf8Json.Formatters
             for (int i = 0; i < names.Count; i++)
             {
                 nameValueMapping.Add(JsonWriter.GetEncodedPropertyNameWithoutQuotation(names[i]), (T)values[i]);
+                if (!string.Equals(names[i], names[i].ToLower()))
+                {
+                    nameValueMapping.Add(JsonWriter.GetEncodedPropertyNameWithoutQuotation(names[i].ToLower()), (T)values[i]);
+                }
                 valueNameMapping[(T)values[i]] = names[i];
             }
 

--- a/tests/Utf8Json.Tests/EnumAsStringTest.cs
+++ b/tests/Utf8Json.Tests/EnumAsStringTest.cs
@@ -96,6 +96,25 @@ namespace Utf8Json.Tests
             JsonSerializer.Deserialize<T?>(bin2).Is(y);
         }
 
+        public static object enumLowerCaseData = new object[]
+        {
+            new object[] { AsString.Foo, "foo" },
+            new object[] { AsString.Bar, "bar" },
+            new object[] { AsString.Baz, "baz" },
+            new object[] { AsString.FooBar, "foobar" },
+            new object[] { AsString.FooBaz, "foobaz" },
+            new object[] { AsString.BarBaz, "barbaz" },
+            new object[] { AsString.FooBarBaz, "foobarbaz" }
+        };
+
+        [Theory]
+        [MemberData(nameof(enumLowerCaseData))]
+        public void EnumLowerCaseTest<T>(T x, string name)
+            where T : struct
+        {
+            JsonSerializer.Deserialize<T>($"\"{name}\"").Is(x);
+        }
+
         [Fact]
         public void DataMemberTest()
         {


### PR DESCRIPTION
Deserialize Enum from lower case string.

Some platforms/languages seem to prefer lower case values of equivalent type to Enum.
It should not impact performance much since all changes are done in static code which is cached. The impact is only on nameValueMapping lookup which should be negligible.