### PR TITLE
Make System.Threading.Tasks.Extensions dependency conditional on framework

### DIFF
--- a/src/Utf8Json/Utf8Json.csproj
+++ b/src/Utf8Json/Utf8Json.csproj
@@ -58,12 +58,15 @@
 
     <ItemGroup>
         <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />        
         <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
         <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
 


### PR DESCRIPTION
We have had major problems referencing Utf8Json in a dotnet 462 project, since the current version pulls in a version of System.Threading.Tasks.Extensions that conflicts with other dependencies. (We have had issues using System.Net.Http)
This pull request updates the dependency on System.Threading.Tasks.Extensions to be conditional based on framework since its not used when targeting 4.5