### PR TITLE
Make Infinity and NaN deserialization independent of Culture

### DIFF
--- a/src/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
+++ b/src/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace Utf8Json.Internal.DoubleConversion
@@ -154,8 +154,8 @@ namespace Utf8Json.Internal.DoubleConversion
         const double junk_string_value_ = double.NaN;
         const int kMaxSignificantDigits = 772;
         const int kBufferSize = kMaxSignificantDigits + 10;
-        static readonly byte[] infinity_symbol_ = StringEncoding.UTF8.GetBytes(double.PositiveInfinity.ToString());
-        static readonly byte[] nan_symbol_ = StringEncoding.UTF8.GetBytes(double.NaN.ToString());
+        static readonly byte[] infinity_symbol_ = StringEncoding.UTF8.GetBytes(double.PositiveInfinity.ToString(CultureInfo.InvariantCulture));
+        static readonly byte[] nan_symbol_ = StringEncoding.UTF8.GetBytes(double.NaN.ToString(CultureInfo.InvariantCulture));
 
         static readonly byte[] kWhitespaceTable7 = new byte[] { 32, 13, 10, 9, 11, 12 };
         static readonly int kWhitespaceTable7Length = kWhitespaceTable7.Length;


### PR DESCRIPTION
double.PositiveInfinity, NaN string representations depends on culture settings. E.g. PositiveInfinity can be "Infinity", "∞", "бесконечность" and so on. Therefore, current code in StringToDoubleConverter may fail on Infinity and NaN deserialization.

In this PR I use InvariantCulture ToString conversion for double.NaN and double.PositiveInfinity to avoid it.