### PR TITLE
Fix reading beyond array end in DateTimeFormatter

### DIFF
--- a/src/Utf8Json/Formatters/DateTimeFormatter.cs
+++ b/src/Utf8Json/Formatters/DateTimeFormatter.cs
@@ -335,7 +335,7 @@ namespace Utf8Json.Formatters
             {
                 kind = DateTimeKind.Utc;
             }
-            else if (i < to && array[i] == '-' || array[i] == '+')
+            else if (i < to && (array[i] == '-' || array[i] == '+'))
             {
                 if (!(i + 5 < to)) goto ERROR;
 
@@ -681,7 +681,7 @@ namespace Utf8Json.Formatters
 
             END_TICKS:
 
-            if (i < to && array[i] == '-' || array[i] == '+')
+            if (i < to && (array[i] == '-' || array[i] == '+'))
             {
                 if (!(i + 5 < to)) goto ERROR;
 


### PR DESCRIPTION
`&&` has priority over `||` and the second check after `||` is done when `i < to`