### PR TITLE
Create single arity generic type formatter from JsonFormatterAttribute

### DIFF
--- a/src/Utf8Json/Resolvers/DynamicObjectResolver.cs
+++ b/src/Utf8Json/Resolvers/DynamicObjectResolver.cs
@@ -697,8 +697,17 @@ namespace Utf8Json.Resolvers.Internal
             {
                 var attr = item.GetCustomAttribute<JsonFormatterAttribute>(true);
                 if (attr != null)
-                {
-                    var formatter = Activator.CreateInstance(attr.FormatterType, attr.Arguments);
+				{
+					var formatterType = attr.FormatterType;
+
+					if (attr.FormatterType.IsGenericType &&
+						!attr.FormatterType.IsConstructedGenericType &&
+						attr.FormatterType.GetTypeInfo().GenericTypeParameters.Length == 1)
+					{
+						formatterType = attr.FormatterType.MakeGenericType(item.PropertyInfo.PropertyType);
+					}
+
+                    var formatter = Activator.CreateInstance(formatterType, attr.Arguments);
                     serializeCustomFormatters.Add(formatter);
                 }
                 else
@@ -711,7 +720,16 @@ namespace Utf8Json.Resolvers.Internal
                 var attr = item.GetCustomAttribute<JsonFormatterAttribute>(true);
                 if (attr != null)
                 {
-                    var formatter = Activator.CreateInstance(attr.FormatterType, attr.Arguments);
+					var formatterType = attr.FormatterType;
+
+					if (attr.FormatterType.IsGenericType &&
+						!attr.FormatterType.IsConstructedGenericType &&
+						attr.FormatterType.GetTypeInfo().GenericTypeParameters.Length == 1)
+					{
+						formatterType = attr.FormatterType.MakeGenericType(item.PropertyInfo.PropertyType);
+					}
+
+                    var formatter = Activator.CreateInstance(formatterType, attr.Arguments);
                     deserializeCustomFormatters.Add(formatter);
                 }
                 else


### PR DESCRIPTION
This PR allows the construction of a closed generic type `IJsonFormatter<T>`
from a `JsonFormatterAttribute` on a property of a generic type,
where the property type is a generic parameter, and the
`IJsonFormatter<T>` is an open generic type.

Consider

```c#
public class Foo<T>
{
    public T Bar { get; set; }
}
```

We may wish to define an `IJsonFormatter<T>` for property `Bar`. This
commit allows the following

```c#
public class Foo<T>
{
    [JsonFormatter(typeof(BarFormatter<>)]
    public T Bar { get; set; }
}
```

without needing to introduce a formatter for `Foo<T>`