### PR TITLE
Opt in member serialization

### DIFF
--- a/src/Utf8Json/Attributes.cs
+++ b/src/Utf8Json/Attributes.cs
@@ -27,4 +27,10 @@ namespace Utf8Json
     {
 
     }
+    
+    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public class InterfaceDataContractAttribute : Attribute
+    {
+
+    }
 }

--- a/src/Utf8Json/Internal/Emit/MetaType.cs
+++ b/src/Utf8Json/Internal/Emit/MetaType.cs
@@ -21,10 +21,11 @@ namespace Utf8Json.Internal.Emit
         {
             var ti = type.GetTypeInfo();
             var isClass = ti.IsClass || ti.IsInterface || ti.IsAbstract;
+            var dataContractPresent = type.GetCustomAttribute<DataContractAttribute>(true) != null ||
+                                      type.GetCustomAttribute<InterfaceDataContractAttribute>(true) != null;
 
             this.Type = type;
 
-			var dataContractPresent = type.GetCustomAttribute<DataContractAttribute>(true) != null;
             var stringMembers = new Dictionary<string, MetaMember>();
 
             {

--- a/src/Utf8Json/Internal/Emit/MetaType.cs
+++ b/src/Utf8Json/Internal/Emit/MetaType.cs
@@ -23,6 +23,8 @@ namespace Utf8Json.Internal.Emit
             var isClass = ti.IsClass || ti.IsInterface || ti.IsAbstract;
 
             this.Type = type;
+
+			var dataContractPresent = type.GetCustomAttribute<DataContractAttribute>(true) != null;
             var stringMembers = new Dictionary<string, MetaMember>();
 
             {
@@ -32,6 +34,7 @@ namespace Utf8Json.Internal.Emit
                     if (item.GetCustomAttribute<IgnoreDataMemberAttribute>(true) != null) continue;
 
                     var dm = item.GetCustomAttribute<DataMemberAttribute>(true);
+					if (dataContractPresent && dm == null) continue;
                     var name = (dm != null && dm.Name != null) ? dm.Name : nameMutetor(item.Name);
 
                     var member = new MetaMember(item, name, allowPrivate);
@@ -51,6 +54,7 @@ namespace Utf8Json.Internal.Emit
                     if (item.Name.StartsWith("<")) continue; // compiler generated field(anonymous type, etc...)
 
                     var dm = item.GetCustomAttribute<DataMemberAttribute>(true);
+					if (dataContractPresent && dm == null) continue;
                     var name = (dm != null && dm.Name != null) ? dm.Name : nameMutetor(item.Name);
 
                     var member = new MetaMember(item, name, allowPrivate);

--- a/tests/Utf8Json.Tests/DataContractTest.cs
+++ b/tests/Utf8Json.Tests/DataContractTest.cs
@@ -17,15 +17,6 @@ namespace Utf8Json.Tests
     public class DataContractTest
     {
         [DataContract]
-        public class MyClass
-        {
-            [DataMember(Order = 0)]
-            public int MyProperty1 { get; set; }
-            [DataMember(Order = 1)]
-            public string MyProperty2;
-        }
-
-        [DataContract]
         public class MyClass1
         {
             [DataMember(Name = "mp1")]
@@ -40,11 +31,21 @@ namespace Utf8Json.Tests
             [DataMember]
             public int MyProperty1 { get; set; }
             [DataMember]
-            public string MyProperty2;
+            public string MyProperty2;           
+            public string MyProperty3 { get; set; }
+        }
+        
+        public class MyClass3
+        {
+            [DataMember]
+            public int MyProperty1 { get; set; }          
+            public string MyProperty2 { get; set; }          
+            [DataMember]
+            public string MyProperty3;
         }
 
         [Fact]
-        public void SerializeName()
+        public void SerializeDataMemberName()
         {
             var mc = new MyClass1 { MyProperty1 = 100, MyProperty2 = "foobar" };
 
@@ -59,17 +60,35 @@ namespace Utf8Json.Tests
         }
 
         [Fact]
-        public void Serialize()
+        public void SerializeOnlyDataMemberWhenDataContract()
         {
-            var mc = new MyClass2 { MyProperty1 = 100, MyProperty2 = "foobar" };
+            var mc = new MyClass2 { MyProperty1 = 100, MyProperty2 = "foobar", MyProperty3 = "baz" };
 
             var bin = JsonSerializer.Serialize(mc);
+            
+            Encoding.UTF8.GetString(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar""}");
+            
             var mc2 = JsonSerializer.Deserialize<MyClass2>(bin);
 
             mc.MyProperty1.Is(mc2.MyProperty1);
             mc.MyProperty2.Is(mc2.MyProperty2);
+            mc.MyProperty3.IsNot(mc2.MyProperty3);
+            mc2.MyProperty3.Is(null);
+        }
+        
+        [Fact]
+        public void Serialize()
+        {
+            var mc = new MyClass3 { MyProperty1 = 100, MyProperty2 = "foobar", MyProperty3 = "baz" };
 
-            Encoding.UTF8.GetString(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar""}");
+            var bin = JsonSerializer.Serialize(mc);
+            var mc2 = JsonSerializer.Deserialize<MyClass3>(bin);
+            
+            Encoding.UTF8.GetString(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar"",""MyProperty3"":""baz""}");
+
+            mc.MyProperty1.Is(mc2.MyProperty1);
+            mc.MyProperty2.Is(mc2.MyProperty2);
+            mc.MyProperty3.Is(mc2.MyProperty3);
         }
     }
 

--- a/tests/Utf8Json.Tests/DataContractTest.cs
+++ b/tests/Utf8Json.Tests/DataContractTest.cs
@@ -43,6 +43,30 @@ namespace Utf8Json.Tests
             [DataMember]
             public string MyProperty3;
         }
+        
+        [InterfaceDataContract]
+        public interface IMyClass4
+        {
+            [DataMember]
+            int MyProperty1 { get; set; }  
+            
+            string MyProperty2 { get; set; }
+        }
+
+        public class MyClass4 : IMyClass4
+        {
+            public int MyProperty1 { get; set; }
+            [DataMember]
+            public string MyProperty2 { get; set; }
+        }
+        
+        [DataContract]
+        public class MyOtherClass4 : IMyClass4
+        {
+            public int MyProperty1 { get; set; }
+            [DataMember]
+            public string MyProperty2 { get; set; }
+        }
 
         [Fact]
         public void SerializeDataMemberName()
@@ -50,11 +74,9 @@ namespace Utf8Json.Tests
             var mc = new MyClass1 { MyProperty1 = 100, MyProperty2 = "foobar" };
 
             var bin = JsonSerializer.Serialize(mc);
-
             Encoding.UTF8.GetString(bin).Is(@"{""mp1"":100,""mp2"":""foobar""}");
 
             var mc2 = JsonSerializer.Deserialize<MyClass1>(bin);
-
             mc.MyProperty1.Is(mc2.MyProperty1);
             mc.MyProperty2.Is(mc2.MyProperty2);
         }
@@ -65,11 +87,9 @@ namespace Utf8Json.Tests
             var mc = new MyClass2 { MyProperty1 = 100, MyProperty2 = "foobar", MyProperty3 = "baz" };
 
             var bin = JsonSerializer.Serialize(mc);
-            
             Encoding.UTF8.GetString(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar""}");
             
             var mc2 = JsonSerializer.Deserialize<MyClass2>(bin);
-
             mc.MyProperty1.Is(mc2.MyProperty1);
             mc.MyProperty2.Is(mc2.MyProperty2);
             mc.MyProperty3.IsNot(mc2.MyProperty3);
@@ -82,13 +102,40 @@ namespace Utf8Json.Tests
             var mc = new MyClass3 { MyProperty1 = 100, MyProperty2 = "foobar", MyProperty3 = "baz" };
 
             var bin = JsonSerializer.Serialize(mc);
-            var mc2 = JsonSerializer.Deserialize<MyClass3>(bin);
-            
             Encoding.UTF8.GetString(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar"",""MyProperty3"":""baz""}");
 
+            var mc2 = JsonSerializer.Deserialize<MyClass3>(bin);
             mc.MyProperty1.Is(mc2.MyProperty1);
             mc.MyProperty2.Is(mc2.MyProperty2);
             mc.MyProperty3.Is(mc2.MyProperty3);
+        }
+
+        [Fact]
+        public void SerializeInterfaceOnlyDataMemberWhenInterfaceDataContract()
+        {
+            IMyClass4 mc = new MyClass4 { MyProperty1 = 100, MyProperty2 = "foobar" };
+
+            var bin = JsonSerializer.Serialize(mc);
+            Encoding.UTF8.GetString(bin).Is(@"{""MyProperty1"":100}");
+            
+            var mc2 = JsonSerializer.Deserialize<MyClass4>(bin);
+            mc.MyProperty1.Is(mc2.MyProperty1);
+            mc.MyProperty2.IsNot(mc2.MyProperty2);
+            mc2.MyProperty2.Is(null);
+        }
+        
+        [Fact]
+        public void SerializeConcreteOnlyDataMemberWhenDataContract()
+        {
+            var mc = new MyOtherClass4 { MyProperty1 = 100, MyProperty2 = "foobar" };
+
+            var bin = JsonSerializer.Serialize(mc);
+            Encoding.UTF8.GetString(bin).Is(@"{""MyProperty2"":""foobar""}");
+            
+            var mc2 = JsonSerializer.Deserialize<MyOtherClass4>(bin);
+            mc.MyProperty1.IsNot(mc2.MyProperty1);
+            mc2.MyProperty1.Is(0);
+            mc.MyProperty2.Is(mc2.MyProperty2);
         }
     }
 


### PR DESCRIPTION
This PR adds support for 

- attributing a type with `DataContractAttribute` to signal that only type members explicitly attributed with `DataMemberAttribute` should be included for serialization
- attributing an interface with `InterfaceDataContractAttribute` to signal that only type members explicitly attributed with `DataMemberAttribute` should be included for serialization. `DataContractAttribute` cannot be applied to interfaces, but serializing a concrete instance of a type that implements an interface by using the interface is a valid use case.