### PR TITLE
Ignore case enum parsing

### DIFF
--- a/src/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/Utf8Json/Formatters/EnumFormatter.cs
@@ -250,7 +250,7 @@ namespace Utf8Json.Formatters
                 if (!nameValueMapping.TryGetValue(key, out value))
                 {
                     var str = StringEncoding.UTF8.GetString(key.Array, key.Offset, key.Count);
-                    value = (T)Enum.Parse(typeof(T), str); // Enum.Parse is slow
+                    value = (T)Enum.Parse(typeof(T), str, true); // Enum.Parse is slow
                 }
                 return value;
             }


### PR DESCRIPTION
We are currently moving from JIL to Utf8json, but have found that the enum parsing is case sensitive, unlike in JIL, which parses enums irrespective of the casing. Wondering if there is any reason not to support case insensitive enum parsing, if not can we please add this feature asap?

Tagging @neuecc