### PR TITLE
Clean up input and output formatters

### DIFF
--- a/src/Utf8Json.AspNetCoreMvcFormatter/Formatter.cs
+++ b/src/Utf8Json.AspNetCoreMvcFormatter/Formatter.cs
@@ -26,6 +26,8 @@ namespace Utf8Json.AspNetCoreMvcFormatter
 
         public Task WriteAsync(OutputFormatterWriteContext context)
         {
+            context.HttpContext.Response.ContentType = ContentType;
+            
             var objectType = context.ObjectType;
             var obj = context.Object;
 

--- a/src/Utf8Json.AspNetCoreMvcFormatter/Formatter.cs
+++ b/src/Utf8Json.AspNetCoreMvcFormatter/Formatter.cs
@@ -3,82 +3,79 @@ using System.Threading.Tasks;
 
 namespace Utf8Json.AspNetCoreMvcFormatter
 {
-    public class JsonOutputFormatter : IOutputFormatter //, IApiResponseTypeMetadataProvider
+    public class Utf8JsonOutputFormatter : IOutputFormatter
     {
-        const string ContentType = "application/json";
-        static readonly string[] SupportedContentTypes = new[] { ContentType };
+        private const string ContentType = "application/json";
+        private readonly IJsonFormatterResolver _jsonFormatterResolver;
 
-        readonly IJsonFormatterResolver resolver;
-
-        public JsonOutputFormatter()
-            : this(null)
+        public Utf8JsonOutputFormatter() : this(null)
         {
-
-        }
-        public JsonOutputFormatter(IJsonFormatterResolver resolver)
-        {
-            this.resolver = resolver ?? JsonSerializer.DefaultResolver;
         }
 
-        //public IReadOnlyList<string> GetSupportedContentTypes(string contentType, Type objectType)
-        //{
-        //    return SupportedContentTypes;
-        //}
+        public Utf8JsonOutputFormatter(
+            IJsonFormatterResolver jsonFormatterResolver)
+            => _jsonFormatterResolver =
+                jsonFormatterResolver ?? JsonSerializer.DefaultResolver;
 
         public bool CanWriteResult(OutputFormatterCanWriteContext context)
-        {
-            return true;
-        }
+            => context.HttpContext.Request.Headers.TryGetValue(
+                   "Accept",
+                   out var acceptValues) &&
+               acceptValues.All(accept => accept.Contains(
+                   ContentType));
 
         public Task WriteAsync(OutputFormatterWriteContext context)
         {
-            context.HttpContext.Response.ContentType = ContentType;
+            var objectType = context.ObjectType;
+            var obj = context.Object;
 
-            // when 'object' use the concrete type(object.GetType())
-            if (context.ObjectType == typeof(object))
-            {
-                return JsonSerializer.NonGeneric.SerializeAsync(context.HttpContext.Response.Body, context.Object, resolver);
-            }
-            else
-            {
-                return JsonSerializer.NonGeneric.SerializeAsync(context.ObjectType, context.HttpContext.Response.Body, context.Object, resolver);
-            }
+            var serializeType = objectType == typeof(object)
+                ? obj.GetType()
+                : objectType;
+
+            return JsonSerializer.NonGeneric.SerializeAsync(
+                serializeType,
+                context.HttpContext.Response.Body,
+                obj,
+                _jsonFormatterResolver);
         }
     }
 
-    public class JsonInputFormatter : IInputFormatter // , IApiRequestFormatMetadataProvider
+    public class Utf8JsonInputFormatter : IInputFormatter
     {
-        const string ContentType = "application/json";
-        static readonly string[] SupportedContentTypes = new[] { ContentType };
+        private const string ContentType = "application/json";
+        private readonly IJsonFormatterResolver _jsonFormatterResolver;
 
-        readonly IJsonFormatterResolver resolver;
-
-        public JsonInputFormatter()
-            : this(null)
+        public Utf8JsonInputFormatter() : this(null)
         {
-
         }
 
-        public JsonInputFormatter(IJsonFormatterResolver resolver)
-        {
-            this.resolver = resolver ?? JsonSerializer.DefaultResolver;
-        }
-
-        //public IReadOnlyList<string> GetSupportedContentTypes(string contentType, Type objectType)
-        //{
-        //    return SupportedContentTypes;
-        //}
+        public Utf8JsonInputFormatter(
+            IJsonFormatterResolver jsonFormatterResolver)
+            => _jsonFormatterResolver =
+                jsonFormatterResolver ?? JsonSerializer.DefaultResolver;
 
         public bool CanRead(InputFormatterContext context)
-        {
-            return true;
-        }
+            => context.HttpContext.Request.ContentType ==
+               ContentType;
 
-        public Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
+        public async Task<InputFormatterResult> ReadAsync(
+            InputFormatterContext context)
         {
-            var request = context.HttpContext.Request;
-            var result = JsonSerializer.NonGeneric.Deserialize(context.ModelType, request.Body, resolver);
-            return InputFormatterResult.SuccessAsync(result);
+            try
+            {
+                var model = await JsonSerializer.NonGeneric
+                    .DeserializeAsync(
+                        context.ModelType,
+                        context.HttpContext.Request.Body,
+                        _jsonFormatterResolver)
+                    .ConfigureAwait(false);
+                return InputFormatterResult.Success(model);
+            }
+            catch (JsonParsingException)
+            {
+                return InputFormatterResult.Failure();
+            }
         }
     }
 }


### PR DESCRIPTION
- Handles `JsonParsingException` when the input JSON cannot be parsed
- Examines client’s `Accept` header to decide whether JSON can be returned