### PR TITLE
Fix: Fixed comment reading in the end of file

### DIFF
--- a/src/Utf8Json/JsonReader.cs
+++ b/src/Utf8Json/JsonReader.cs
@@ -1194,7 +1194,7 @@ namespace Utf8Json
                 offset += 2;
                 for (int i = offset; i < bytes.Length; i++)
                 {
-                    if (bytes[i] == '\r' || bytes[i] == '\n')
+                    if (bytes[i] == '\r' || bytes[i] == '\n' || bytes[i] == '\0')
                     {
                         return i;
                     }


### PR DESCRIPTION
Reading failed in jsons like
```
{
    "field": "value"
}
// this comment will break up reading
```
due to the fact that '\0' symbol is not processed.