### PR TITLE
Fixed bug in binary search: replaced signed with unsigned comparison.

### DIFF
--- a/src/Utf8Json/Internal/AutomataDictionary.cs
+++ b/src/Utf8Json/Internal/AutomataDictionary.cs
@@ -451,7 +451,7 @@ namespace Utf8Json.Internal
                     // if(key < mid)
                     il.EmitLdloc(key);
                     il.EmitULong(mid);
-                    il.Emit(OpCodes.Bge, gotoRight);
+                    il.Emit(OpCodes.Bge_Un, gotoRight);
                     EmitSearchNextCore(il, p, rest, key, onFound, onNotFound, l, l.Length);
 
                     // else


### PR DESCRIPTION
I found a bug in the code generation for the binary search in AutomataDictionary. A signed comparison is emitted where an unsigned one is needed. This can lead to strange situations where random fields are not deserialized dependent on their naming.