### PR TITLE
#118 Introduce supporting Case Sensitive in Standard Resolver

### DIFF
--- a/src/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
+++ b/src/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
@@ -60,8 +60,19 @@ namespace Utf8Json.Formatters
 
     public sealed class NullableStringFormatter : IJsonFormatter<string>, IObjectPropertyNameFormatter<string>
     {
-        public static readonly IJsonFormatter<string> Default = new NullableStringFormatter();
-
+        public static readonly IJsonFormatter<string> Default = new NullableStringFormatter(StringMutator.Original);
+        private static Func<string, string> _nameMutator;
+        
+        public NullableStringFormatter()
+        {
+            _nameMutator = StringMutator.Original;
+        }
+        
+        public NullableStringFormatter(Func<string, string> valueNameMutator)
+        {
+            _nameMutator = valueNameMutator;
+        }
+        
         public void Serialize(ref JsonWriter writer, string value, IJsonFormatterResolver formatterResolver)
         {
             writer.WriteString(value);
@@ -74,12 +85,12 @@ namespace Utf8Json.Formatters
 
         public void SerializeToPropertyName(ref JsonWriter writer, string value, IJsonFormatterResolver formatterResolver)
         {
-            writer.WriteString(value);
+            writer.WriteString(_nameMutator.Invoke(value));
         }
 
         public string DeserializeFromPropertyName(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
         {
-            return reader.ReadString();
+            return _nameMutator.Invoke(reader.ReadString());
         }
     }
 

--- a/src/Utf8Json/Resolvers/BuiltinResolver.cs
+++ b/src/Utf8Json/Resolvers/BuiltinResolver.cs
@@ -73,7 +73,6 @@ namespace Utf8Json.Resolvers
                 {typeof(TimeSpan?), new StaticNullableFormatter<TimeSpan>(ISO8601TimeSpanFormatter.Default)},
                 {typeof(DateTimeOffset?),new StaticNullableFormatter<DateTimeOffset>(ISO8601DateTimeOffsetFormatter.Default)},
 
-                {typeof(string), NullableStringFormatter.Default},
                 {typeof(char), CharFormatter.Default},
                 {typeof(Nullable<char>), NullableCharFormatter.Default},
                 {typeof(decimal), DecimalFormatter.Default},

--- a/src/Utf8Json/Resolvers/StandardResolver.cs
+++ b/src/Utf8Json/Resolvers/StandardResolver.cs
@@ -87,7 +87,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.Default }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.Original,
+                DynamicObjectResolver.Default
+            }).ToArray();
 
             InnerResolver()
             {
@@ -155,7 +159,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.CamelCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.CamelCase,
+                DynamicObjectResolver.CamelCase
+            }).ToArray();
 
             InnerResolver()
             {
@@ -223,7 +231,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.SnakeCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.SnakeCase,
+                DynamicObjectResolver.SnakeCase
+            }).ToArray();
 
             InnerResolver()
             {
@@ -291,7 +303,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.ExcludeNull }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.Original,
+                DynamicObjectResolver.ExcludeNull
+            }).ToArray();
 
             InnerResolver()
             {
@@ -359,7 +375,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.ExcludeNullCamelCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.CamelCase,
+                DynamicObjectResolver.ExcludeNullCamelCase
+            }).ToArray();
 
             InnerResolver()
             {
@@ -497,7 +517,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivate }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.Original,
+                DynamicObjectResolver.AllowPrivate
+            }).ToArray();
 
             InnerResolver()
             {
@@ -566,7 +590,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateCamelCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.CamelCase,
+                DynamicObjectResolver.AllowPrivateCamelCase,
+            }).ToArray();
 
             InnerResolver()
             {
@@ -635,7 +663,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateSnakeCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.SnakeCase,
+                DynamicObjectResolver.AllowPrivateSnakeCase
+            }).ToArray();
 
             InnerResolver()
             {
@@ -704,7 +736,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateExcludeNull }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.Original,
+                DynamicObjectResolver.AllowPrivateExcludeNull
+            }).ToArray();
 
             InnerResolver()
             {
@@ -773,7 +809,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateExcludeNullCamelCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.CamelCase,
+                DynamicObjectResolver.AllowPrivateExcludeNullCamelCase
+            }).ToArray();
 
             InnerResolver()
             {
@@ -842,7 +882,11 @@ namespace Utf8Json.Resolvers.Internal
         {
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
-            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateExcludeNullSnakeCase }).ToArray();
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[]
+            {
+                StandardStringResolver.SnakeCase,
+                DynamicObjectResolver.AllowPrivateExcludeNullSnakeCase
+            }).ToArray();
 
             InnerResolver()
             {

--- a/src/Utf8Json/Resolvers/StandardStringResolver.cs
+++ b/src/Utf8Json/Resolvers/StandardStringResolver.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Reflection;
+using Utf8Json.Formatters;
+using Utf8Json.Internal;
+
+namespace Utf8Json.Resolvers
+{
+    internal static class StandardStringResolver
+    {
+        /// <summary>Serialize as is.</summary>
+        public static readonly IJsonFormatterResolver Original = StringDefaultResolver.Instance;
+
+        /// <summary>Serialize as CamelCase.</summary>
+        public static readonly IJsonFormatterResolver CamelCase = StringCamelCaseValueResolver.Instance;
+
+        /// <summary>Serialize as SnakeCase.</summary>
+        public static readonly IJsonFormatterResolver SnakeCase =
+            StringCamelCaseValueResolver.StringSnakeCaseValueResolver.Instance;
+    }
+
+    internal sealed class StringDefaultResolver : IJsonFormatterResolver
+    {
+        public static readonly IJsonFormatterResolver Instance = new StringDefaultResolver();
+
+        StringDefaultResolver()
+        {
+        }
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                var ti = typeof(T).GetTypeInfo();
+
+                if (ti.IsNullable())
+                {
+                    // build underlying type and use wrapped formatter.
+                    ti = ti.GenericTypeArguments[0].GetTypeInfo();
+                    if (!ti.IsEnum)
+                    {
+                        return;
+                    }
+
+                    var innerFormatter = Instance.GetFormatterDynamic(ti.AsType());
+                    if (innerFormatter == null)
+                    {
+                        return;
+                    }
+
+                    formatter = (IJsonFormatter<T>) Activator.CreateInstance(
+                        typeof(StaticNullableFormatter<>).MakeGenericType(ti.AsType()), innerFormatter);
+                    return;
+                }
+
+                if (ti == typeof(string))
+                {
+                    formatter = (IJsonFormatter<T>) (object) NullableStringFormatter.Default;
+                }
+            }
+        }
+    }
+
+    internal sealed class StringCamelCaseValueResolver : IJsonFormatterResolver
+    {
+        public static readonly IJsonFormatterResolver Instance = new StringCamelCaseValueResolver();
+
+        StringCamelCaseValueResolver()
+        {
+        }
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                var ti = typeof(T).GetTypeInfo();
+
+                if (ti.IsNullable())
+                {
+                    // build underlying type and use wrapped formatter.
+                    ti = ti.GenericTypeArguments[0].GetTypeInfo();
+                    if (!ti.IsEnum)
+                    {
+                        return;
+                    }
+
+                    var innerFormatter = Instance.GetFormatterDynamic(ti.AsType());
+                    if (innerFormatter == null)
+                    {
+                        return;
+                    }
+
+                    formatter = (IJsonFormatter<T>) Activator.CreateInstance(
+                        typeof(StaticNullableFormatter<>).MakeGenericType(ti.AsType()), innerFormatter);
+                    return;
+                }
+
+                if (ti == typeof(string))
+                {
+                    formatter = (IJsonFormatter<T>) (object) new NullableStringFormatter(StringMutator.ToCamelCase);
+                }
+            }
+        }
+
+        internal sealed class StringSnakeCaseValueResolver : IJsonFormatterResolver
+        {
+            public static readonly IJsonFormatterResolver Instance = new StringSnakeCaseValueResolver();
+
+            StringSnakeCaseValueResolver()
+            {
+            }
+
+            public IJsonFormatter<T> GetFormatter<T>()
+            {
+                return FormatterCache<T>.formatter;
+            }
+
+            static class FormatterCache<T>
+            {
+                public static readonly IJsonFormatter<T> formatter;
+
+                static FormatterCache()
+                {
+                    var ti = typeof(T).GetTypeInfo();
+
+                    if (ti.IsNullable())
+                    {
+                        // build underlying type and use wrapped formatter.
+                        ti = ti.GenericTypeArguments[0].GetTypeInfo();
+                        if (!ti.IsEnum)
+                        {
+                            return;
+                        }
+
+                        var innerFormatter = Instance.GetFormatterDynamic(ti.AsType());
+                        if (innerFormatter == null)
+                        {
+                            return;
+                        }
+
+                        formatter = (IJsonFormatter<T>) Activator.CreateInstance(
+                            typeof(StaticNullableFormatter<>).MakeGenericType(ti.AsType()), innerFormatter);
+                        return;
+                    }
+
+                    if (ti == typeof(string))
+                    {
+                        formatter = (IJsonFormatter<T>) (object) new NullableStringFormatter(StringMutator.ToSnakeCase);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Utf8Json.Tests/DataContractTest.cs
+++ b/tests/Utf8Json.Tests/DataContractTest.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Text;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Utf8Json.Tests


### PR DESCRIPTION
### Changes are focused on fix bugs for Standard Resolver case sensitive, especially was triggered for Dictionary 

**What have I completed in the scope of introducing new resolvers?**

- [x] Added three resolvers for string
- StringDefaultResolver (as we had previously, so I might have not broken anything)
- StringCamelCaseValueResolver - supports CamelCases
- StringSnakeCaseValueResolver - supports SnakeCase

- [x] Rewrite NullableStringFormatter for string
Added support Name mutator. It has a default behavior and special cases for case sensitivity. Working by Delegate.

- [x] Use String resolvers in StandardResolver
For supporting StandartResolver case-sensitive

- [x] Implemented separate test-cases


If you need additional changes/ improvements, let me know - I'm open.