### PR TITLE
Fix: Fix exponent decimals deserialization

### DIFF
--- a/src/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
+++ b/src/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
@@ -305,7 +305,7 @@ namespace Utf8Json.Formatters
             var token = reader.GetCurrentJsonToken();
             if (token == JsonToken.Number)
             {
-                var number = reader.ReadNumberSegment();
+                var number = reader.ReadNextBlockSegment();
                 return decimal.Parse(StringEncoding.UTF8.GetString(number.Array, number.Offset, number.Count), NumberStyles.Float, CultureInfo.InvariantCulture);
             }
             else if (token == JsonToken.String)

--- a/tests/Utf8Json.Tests/DecimalTest.cs
+++ b/tests/Utf8Json.Tests/DecimalTest.cs
@@ -29,6 +29,7 @@ namespace Utf8Json.Tests
             ddd.More.Is("mmmm");
 
             JsonSerializer.Deserialize<Foo>("{\"Bar\":1.23}").Bar.Is(1.23m);
+            JsonSerializer.Deserialize<Foo>("{\"Bar\":-2.3E-4}").Bar.Is(-2.3E-4m);
         }
     }
 }


### PR DESCRIPTION
Fix for the issue #85 and test for it.

Deserializator is failing to deserialize exponent decimals because it is trying to read a number segment, changed to ReadNextBlockSegment