### PR TITLE
Resolved an issue with List<TimeSpan>

### DIFF
--- a/src/Utf8Json/Formatters/DateTimeFormatter.cs
+++ b/src/Utf8Json/Formatters/DateTimeFormatter.cs
@@ -862,7 +862,7 @@ namespace Utf8Json.Formatters
             {
                 bool foundDot = false;
                 bool foundColon = false;
-                for (int j = i; j < str.Count; j++)
+                for (int j = i; j < to; j++)
                 {
                     if (array[j] == '.')
                     {

--- a/tests/Utf8Json.Tests/DateAndTime.cs
+++ b/tests/Utf8Json.Tests/DateAndTime.cs
@@ -89,6 +89,22 @@ namespace Utf8Json.Tests
             }
         }
 
+        [Fact]
+        public void ListOfTimespansShouldSerialize()
+        {
+            var data = new List<TimeSpan>
+            {
+                TimeSpan.FromHours(1),
+                TimeSpan.FromHours(5),
+                TimeSpan.FromHours(5),
+                TimeSpan.FromDays(1),
+                TimeSpan.FromDays(2)
+            };
+            var serialized = Utf8Json.JsonSerializer.ToJsonString(data);
+            var deSerialized = Utf8Json.JsonSerializer.Deserialize<List<TimeSpan>>(serialized);
+            var serialized2 = Utf8Json.JsonSerializer.ToJsonString(deSerialized);
+            serialized2.Is(serialized);
+        }
 
         [Fact]
         public void ShortFormat()


### PR DESCRIPTION
When any non-first TimeSpan in the list contains a date part, for instance 1.00:00:00, an error is throw instead of parsing the timespan correctly.  A fix for this errant behavior and a unit test to validate the behavior were added.