### PR TITLE
Fixed issue while using JsonReader.ReadStringSegmentRaw on string with trailing backslashes

### DIFF
--- a/src/Utf8Json/JsonReader.cs
+++ b/src/Utf8Json/JsonReader.cs
@@ -769,8 +769,17 @@ namespace Utf8Json
                 {
                     if (bytes[i] == (char)'\"')
                     {
+                        bool escaped = false;
                         // is escape?
-                        if (bytes[i - 1] == (char)'\\')
+                        {
+                            var ii = i;
+                            while (bytes[--ii] == (char)'\\')//We already ensured that this span has leading "
+                            {
+                                escaped = !escaped;
+                            }
+                        }
+
+                        if (escaped)
                         {
                             continue;
                         }

--- a/tests/Utf8Json.Tests/JsonReaderWriterTest.cs
+++ b/tests/Utf8Json.Tests/JsonReaderWriterTest.cs
@@ -265,5 +265,17 @@ namespace Utf8Json.Tests
             // ok, can read.
             reader.GetCurrentOffsetUnsafe().Is(bin.Length);
         }
+
+
+        [Fact]
+        public void TrailingBackSlash()
+        {
+            var str = "\"\\\\\"";
+            var bytes = Encoding.UTF8.GetBytes(str);
+            var reader = new JsonReader(bytes);
+            var strSegment = Encoding.UTF8.GetString(reader.ReadStringSegmentRaw().ToArray());
+            strSegment.Is("\\\\");
+        }
+
     }
 }


### PR DESCRIPTION
`JsonReader.ReadStringSegmentRaw` doesn't handles the case "the double quote's leading back slash was escaped".