### PR TITLE
add property based tests with FsCheck

### DIFF
--- a/tests/Utf8Json.Tests/JsonReaderWriterTest.cs
+++ b/tests/Utf8Json.Tests/JsonReaderWriterTest.cs
@@ -2,6 +2,7 @@ using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Text;
+using FsCheck.Xunit;
 using Xunit;
 
 namespace Utf8Json.Tests
@@ -15,7 +16,7 @@ namespace Utf8Json.Tests
 
             return new JsonReader(result.Array, result.Offset);
         }
-        /*
+
         [Fact]
         public void NullTest()
         {
@@ -23,175 +24,87 @@ namespace Utf8Json.Tests
             writer.WriteNull();
 
             var reader = SameAsReference((object)null, writer.GetBuffer());
-
             reader.ReadIsNull().IsTrue();
         }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        
+        [Property]
         public void BoolTest(bool target)
         {
             var writer = new JsonWriter();
             writer.WriteBoolean(target);
 
             var reader = SameAsReference(target, writer.GetBuffer());
-
             reader.ReadBoolean().Is(target);
         }
-
-        [Theory]
-        [InlineData(byte.MinValue)]
-        [InlineData(9)]
-        [InlineData(10)]
-        [InlineData(99)]
-        [InlineData(100)]
-        [InlineData(101)]
-        [InlineData(byte.MaxValue)]
+        
+        [Property]
         public void ByteTest(byte target)
         {
             var writer = new JsonWriter();
             writer.WriteByte(target);
 
             var reader = SameAsReference(target, writer.GetBuffer());
-
             reader.ReadByte().Is(target);
         }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(12)]
-        [InlineData(123)]
-        [InlineData(12345)]
-        [InlineData(123456)]
-        [InlineData(1234567)]
-        [InlineData(12345678)]
-        [InlineData(123456789)]
-        [InlineData(1234567890)]
-        [InlineData(12345678901)]
-        [InlineData(123456789012)]
-        [InlineData(1234567890123)]
-        [InlineData(12345678901234)]
-        [InlineData(123456789012345)]
-        [InlineData(1234567890123456)]
-        [InlineData(12345678901234567)]
-        [InlineData(123456789012345678)]
-        [InlineData(1234567890123456789)]
-        [InlineData(12345678901234567890)]
-        [InlineData(ulong.MaxValue)]
+        
+        [Property]
         public void UInt64Test(ulong target)
         {
             var writer = new JsonWriter();
             writer.WriteUInt64(target);
 
             var reader = SameAsReference(target, writer.GetBuffer());
-
             reader.ReadUInt64().Is(target);
         }
-
-        [Theory]
-        [InlineData(long.MinValue)]
-        [InlineData(-1234567890123456789)]
-        [InlineData(-123456789012345678)]
-        [InlineData(-12345678901234567)]
-        [InlineData(-1234567890123456)]
-        [InlineData(-123456789012345)]
-        [InlineData(-12345678901234)]
-        [InlineData(-1234567890123)]
-        [InlineData(-123456789012)]
-        [InlineData(-12345678901)]
-        [InlineData(-1234567890)]
-        [InlineData(-123456789)]
-        [InlineData(-12345678)]
-        [InlineData(-1234567)]
-        [InlineData(-123456)]
-        [InlineData(-12345)]
-        [InlineData(-1234)]
-        [InlineData(-123)]
-        [InlineData(-12)]
-        [InlineData(-1)]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(12)]
-        [InlineData(123)]
-        [InlineData(12345)]
-        [InlineData(123456)]
-        [InlineData(1234567)]
-        [InlineData(12345678)]
-        [InlineData(123456789)]
-        [InlineData(1234567890)]
-        [InlineData(12345678901)]
-        [InlineData(123456789012)]
-        [InlineData(1234567890123)]
-        [InlineData(12345678901234)]
-        [InlineData(123456789012345)]
-        [InlineData(1234567890123456)]
-        [InlineData(12345678901234567)]
-        [InlineData(123456789012345678)]
-        [InlineData(1234567890123456789L)]
-        [InlineData(long.MaxValue)]
+        
+        [Property]
         public void Int64Test(long target)
         {
             var writer = new JsonWriter();
             writer.WriteInt64(target);
 
             var reader = SameAsReference(target, writer.GetBuffer());
-
             reader.ReadInt64().Is(target);
         }
-
-        [Theory]
-        [InlineData(-10)]
-        [InlineData(-120)]
-        [InlineData(10)]
-        [InlineData(byte.MaxValue)]
-        [InlineData(sbyte.MaxValue)]
-        [InlineData(short.MaxValue)]
-        [InlineData(int.MaxValue)]
-        [InlineData(long.MaxValue)]
-        [InlineData(ushort.MaxValue)]
-        [InlineData(uint.MaxValue)]
-        [InlineData(ulong.MaxValue)]
+                
+        [Property]
         public void FloatTest<T>(T value)
         {
             var bin = JsonSerializer.Serialize(value);
             JsonSerializer.Deserialize<float>(bin).Is(Convert.ToSingle(value));
         }
-
-        [Theory]
-        [InlineData(-10)]
-        [InlineData(-120)]
-        [InlineData(10)]
-        [InlineData(byte.MaxValue)]
-        [InlineData(sbyte.MaxValue)]
-        [InlineData(short.MaxValue)]
-        [InlineData(int.MaxValue)]
-        [InlineData(long.MaxValue)]
-        [InlineData(ushort.MaxValue)]
-        [InlineData(uint.MaxValue)]
-        [InlineData(ulong.MaxValue)]
+        
+        [Property]
         public void DoubleTest<T>(T value)
         {
             var bin = JsonSerializer.Serialize(value);
             JsonSerializer.Deserialize<double>(bin).Is(Convert.ToDouble(value));
         }
-
-        [InlineData("\"xyzzy\"")]
-        [InlineData("/xyzzy/")]
-        [InlineData("'xyzzy'")]
-        [InlineData("\r\nxyzzy\r\n")]
-        [InlineData("xyz\r\nzy")]
-        [InlineData("xy\"zzy")]
-        [InlineData("xy\"zz\"y")]
-        [Theory]
-        public void StringEscaping(string v)
+        
+        [Property]
+        public void StringTest(string v)
         {
             var js = JsonSerializer.Serialize<string>(v);
             var ok = JsonSerializer.Deserialize<string>(js);
             ok.Is(v);
         }
-        */
+                
+        [Property]
+        public void IntArrayTest(int[] origin)
+        {
+            var serialized = JsonSerializer.Serialize(origin);
+            var deserialized = JsonSerializer.Deserialize<int[]>(serialized);
+            Assert.Equal(origin, deserialized);
+        }
+        
+        [Property]
+        public void StringArrayTest(string[] origin)
+        {
+            var serialized = JsonSerializer.Serialize(origin);
+            var deserialized = JsonSerializer.Deserialize<string[]>(serialized);
+            Assert.Equal(origin, deserialized);
+        }
+        
         [Fact]
         public void LargeString()
         {
@@ -204,7 +117,6 @@ namespace Utf8Json.Tests
 
             aaa.Is("\u0313" + origstr);
         }
-
 
         [Fact]
         public void LargeString2()

--- a/tests/Utf8Json.Tests/Utf8Json.Tests.csproj
+++ b/tests/Utf8Json.Tests/Utf8Json.Tests.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCheck.Xunit" Version="2.14.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
originally the bug #213 was found using the FsCheck in my internal project. This will be hopefully fixed soon thanks to PR #220 from @RamType-0

Adding FsCheck proposed since property based tests are:
- more poverful - covering not expected range cases too.
- easier to handle than Theory with InlineData - you don't need to write the input values manually
- especially useful for testing serialize/deserialize loops - generates input for any types and data structures