### PR TITLE
Add asmdef for Unity

### DIFF
--- a/src/Utf8Json.UnityClient/Assets/Scripts/Utf8Json/Utf8Json.asmdef
+++ b/src/Utf8Json.UnityClient/Assets/Scripts/Utf8Json/Utf8Json.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "Utf8Json",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/Utf8Json.UnityClient/Assets/Scripts/Utf8Json/Utf8Json.asmdef.meta
+++ b/src/Utf8Json.UnityClient/Assets/Scripts/Utf8Json/Utf8Json.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d6513ae591a0704d8ca9103251f7e8a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
You can limit the scope of allowing unsafe by adding asmdef.